### PR TITLE
Jfr additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,25 +47,22 @@ As of the today the following is collected
 * All top level conf files in the specified conf folder which is the -C or --dremio-conf-dir flag
 * iostat diagnostic if it is available
 
-### A note on JFRs
-
-Java flight recorder will run on nodes that have a compatible JDK installed. Although it is possible to invoke multiple JFRs on a JVM, this tool checks for existing JFRs before triggering a new one. This is to avoid users unintentionally spawning many JFRs against their running Dremio JVM to avoid any potential issues.
-
-For more information on the JCMD command and how to use it see: https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/tooldescr006.html
-
 ### more help
 
 The help is pretty straight forward and comes with examples
 
 ```sh
 ddc -h
- 
+ddc main-7375a13
 ddc connects via ssh or kubectl and collects a series of logs and files for dremio, then puts those collected files in an archive
 examples:
 
 ddc --coordinator 10.0.0.19 --executors 10.0.0.20,10.0.0.21,10.0.0.22 --ssh-key $HOME/.ssh/id_rsa_dremio --output diag.zip
 
-ddc --k8s --kubectl-path /opt/bin/kubectl --coordinator default:app=dremio-coordinator-dremio --executors default:app=dremio-executor --output diag.tar.gz
+ddc --k8s --kubectl-path /opt/bin/kubectl --coordinator default:app=dremio-coordinator --executors default:app=dremio-executor --output diag.tar.gz
+
+Usage:
+  ddc [flags]
 
 Usage:
   ddc [flags]
@@ -80,15 +77,13 @@ Flags:
   -e, --executors string                      either a common separated list or a ip range of executors nodes to connect to
       --executors-container string            for use with -k8s flag: sets the container name to use to retrieve logs in the executors (default "dremio-executor")
   -h, --help                                  help for ddc
-  -j, --jfr int                               enables collection of java flight recorder (jfr), time specified in seconds
   -k, --k8s                                   use kubernetes to retrieve the diagnostics instead of ssh, instead of hosts pass in labels to the --cordinator and --executors flags
   -p, --kubectl-path string                   where to find kubectl (default "kubectl")
   -a, --log-age int                           the maximum number of days to go back for log retreival (default is no filter and will retrieve all logs)
-  -o, --output string                         filename of the resulting archived (tar) and compressed (gzip) file (default "diag.tgz")
+  -o, --output string                         either a common separated list or a ip range of executors nodes to connect to (default "diag.zip")
   -s, --ssh-key string                        location of ssh key to use to login
   -u, --ssh-user string                       user to use during ssh operations to login
-  -b, --sudo-user string                      if any diagnostcs commands need a sudo user (i.e. for jcmd)
- 
+  
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -7,45 +7,18 @@
 
 collect logs of dremio for analysis
 
-## Install
 
-[Binaries are here](https://github.com/rsvihladremio/dremio-diagnostic-collector/releases)
+## Quick Start
 
-### Mac
-
-Use hombrew
-
-```sh
-brew tap rsvihladremio/ddc
-brew install ddc
-```
-
-### Linux
-
-Use shell script
+On Linux, Mac and WSL run the following script
 
 ```sh
 /bin/bash -c "$(curl https://raw.githubusercontent.com/rsvihladremio/dremio-diagnostic-collector/main/script/install)"
 ```
 
-### Windows
+For all other platforms consult the [installation options](docs/install.md)
 
-Use powershell script
-
-```pwsh
-Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Optional: Needed to run a remote script the first time
-irm https://raw.githubusercontent.com/rsvihladremio/dremio-diagnostic-collector/main/script/install.ps1  | iex 
-```
-## Collection
-
-As of the today the following is collected
-
-* All top level logs in the specified log folder which is the -l or the --dremio-log-dir flag
-* All top level conf files in the specified conf folder which is the -C or --dremio-conf-dir flag
-* iostat diagnostic if it is available
-* flight recorder (jrf) if required
-
-### To collect from Kubernetes deployed clusters
+### dremio on k8s
 
 Just need to specify the namespace and labels of the coordinators and the executors, next you can specify an output file with -o flag
 .tgz, .zip, and .tar.gz are supported
@@ -54,18 +27,25 @@ Just need to specify the namespace and labels of the coordinators and the execut
 /bin/ddc -k -e default:app=dremio-executor -c default:app=dremio-coordinator -o ~/Downloads/k8s-diag.tgz
 ```
 
-### To collect from on-prem
+If you have issues consult the [k8s docs](docs/k8s.md)
 
-This feature relies in ssh and [ssh public authentication](https://www.ssh.com/academy/ssh/public-key-authentication).
-This is well documented in [Windows](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_keymanagement),
-[Linux](https://www.redhat.com/sysadmin/key-based-authentication-ssh), and [Mac](https://www.linode.com/docs/guides/connect-to-server-over-ssh-on-mac/)
+### dremio on prem
 
-You must specify a --ssh-user and an -ssh-key the key must be configured to access the servers and not require a prompt to use (if encrypted using ssh agent will allow it to work).
-The -e and -c flags will take a comma separated list of hosts
+specific executors that you want to collect from with the -e flag and coordinators with the -c flag. Specify ssh user, and ssh key to use.
 
 ```sh
 /bin/ddc -e 192.168.1.12,192.168.1.13 -c 192.168.1.19,192.168.1.2  --ssh-user ubuntu --ssh-key ~/.ssh/id_rsa -o ~/Downloads/k8s-diag.tgz
 ```
+
+If you have issues consult the [ssh docs](docs/ssh.md)
+
+## What is collected?
+
+As of the today the following is collected
+
+* All top level logs in the specified log folder which is the -l or the --dremio-log-dir flag
+* All top level conf files in the specified conf folder which is the -C or --dremio-conf-dir flag
+* iostat diagnostic if it is available
 
 ### A note on JFRs
 
@@ -79,9 +59,7 @@ The help is pretty straight forward and comes with examples
 
 ```sh
 ddc -h
-COMMAND HELP TEXT:
-
-ddc jfr-additions-260d353
+ 
 ddc connects via ssh or kubectl and collects a series of logs and files for dremio, then puts those collected files in an archive
 examples:
 
@@ -110,82 +88,8 @@ Flags:
   -s, --ssh-key string                        location of ssh key to use to login
   -u, --ssh-user string                       user to use during ssh operations to login
   -b, --sudo-user string                      if any diagnostcs commands need a sudo user (i.e. for jcmd)
-
+ 
 ```
 
 
-## Developing
-
-On Linux, Mac, and WSL there are some shell scripts modeled off the [GitHub ones](https://github.com/github/scripts-to-rule-them-all)
-
-to get started run
-
-```sh
-./script/bootstrap
-```
-
-after a pull it is a good idea to run
-
-```sh
-./script/update
-```
-
-tests
-
-```sh
-./script/test
-```
-
-before checkin run
-
-```sh
-./script/cibuild
-```
-
-to cut a release do the following
-
-```sh
-#dont forget to update changelog.md with the release notes
-git tag v0.1.1
-git push origin v0.1.1
-./script/release v0.1.1
-gh repo view -w
-# review the draft and when done set it to publish
-```
-### Windows
-Similarly on Windows there are powershell scripts of the same design
-
-to get started run
-
-```powershell
-.\script\bootstrap.ps1
-```
-
-after a pull it is a good idea to run
-
-```powershell
-.\script\update.ps1
-```
-
-tests
-
-```powershell
-.\script\test.ps1
-```
-
-before checkin run
-
-```powershell
-.\script\cibuild.ps1
-```
-
-to cut a release do the following
-
-```powershell
-#dont forget to update changelog.md with the release notes
-git tag v0.1.1
-.\script\release.ps1 v0.1.1
-gh repo view -w
-# review the draft and when done set it to publish
-```
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ As of the today the following is collected
 * All top level logs in the specified log folder which is the -l or the --dremio-log-dir flag
 * All top level conf files in the specified conf folder which is the -C or --dremio-conf-dir flag
 * iostat diagnostic if it is available
+* flight recorder (jrf) if required
 
 ### To collect from Kubernetes deployed clusters
 
@@ -66,22 +67,27 @@ The -e and -c flags will take a comma separated list of hosts
 /bin/ddc -e 192.168.1.12,192.168.1.13 -c 192.168.1.19,192.168.1.2  --ssh-user ubuntu --ssh-key ~/.ssh/id_rsa -o ~/Downloads/k8s-diag.tgz
 ```
 
+### A note on JFRs
+
+Java flight recorder will run on nodes that have a compatible JDK installed. Although it is possible to invoke multiple JFRs on a JVM, this tool checks for existing JFRs before triggering a new one. This is to avoid users unintentionally spawning many JFRs against their running Dremio JVM to avoid any potential issues.
+
+For more information on the JCMD command and how to use it see: https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/tooldescr006.html
+
 ### more help
 
 The help is pretty straight forward and comes with examples
 
 ```sh
 ddc -h
-ddc main-7375a13
+COMMAND HELP TEXT:
+
+ddc jfr-additions-260d353
 ddc connects via ssh or kubectl and collects a series of logs and files for dremio, then puts those collected files in an archive
 examples:
 
 ddc --coordinator 10.0.0.19 --executors 10.0.0.20,10.0.0.21,10.0.0.22 --ssh-key $HOME/.ssh/id_rsa_dremio --output diag.zip
 
-ddc --k8s --kubectl-path /opt/bin/kubectl --coordinator default:app=dremio-coordinator --executors default:app=dremio-executor --output diag.tar.gz
-
-Usage:
-  ddc [flags]
+ddc --k8s --kubectl-path /opt/bin/kubectl --coordinator default:app=dremio-coordinator-dremio --executors default:app=dremio-executor --output diag.tar.gz
 
 Usage:
   ddc [flags]
@@ -96,13 +102,15 @@ Flags:
   -e, --executors string                      either a common separated list or a ip range of executors nodes to connect to
       --executors-container string            for use with -k8s flag: sets the container name to use to retrieve logs in the executors (default "dremio-executor")
   -h, --help                                  help for ddc
+  -j, --jfr int                               enables collection of java flight recorder (jfr), time specified in seconds
   -k, --k8s                                   use kubernetes to retrieve the diagnostics instead of ssh, instead of hosts pass in labels to the --cordinator and --executors flags
   -p, --kubectl-path string                   where to find kubectl (default "kubectl")
   -a, --log-age int                           the maximum number of days to go back for log retreival (default is no filter and will retrieve all logs)
-  -o, --output string                         either a common separated list or a ip range of executors nodes to connect to (default "diag.zip")
+  -o, --output string                         filename of the resulting archived (tar) and compressed (gzip) file (default "diag.tgz")
   -s, --ssh-key string                        location of ssh key to use to login
   -u, --ssh-user string                       user to use during ssh operations to login
-  
+  -b, --sudo-user string                      if any diagnostcs commands need a sudo user (i.e. for jcmd)
+
 ```
 
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -53,7 +53,10 @@ type Cli struct {
 }
 
 func (c *Cli) Execute(args ...string) (string, error) {
-	//log.Printf("args: %v", args) // useful for debugging
+	// useful for debugging
+	/*for _, arg := range args {
+		log.Printf("arg of args: %v", arg)
+	}*/
 	log.Printf("args: %v", strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stderr = os.Stderr

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ var kubectlPath string
 var isK8s bool
 var durationDiagnosticTooling int
 var logAge int
-var jfrEnable int
+var jfrduration int
 var sudoUser string
 var GitSha = "unknown"
 var Version = "dev"
@@ -101,7 +101,7 @@ ddc --k8s --kubectl-path /opt/bin/kubectl --coordinator default:app=dremio-coord
 			GCLogOverride:             filepath.Clean(dremioGcDir),
 			DurationDiagnosticTooling: durationDiagnosticTooling,
 			LogAge:                    logAge,
-			JfrEnable:                 jfrEnable,
+			JfrDuration:               jfrduration,
 			SudoUser:                  sudoUser,
 		}
 
@@ -190,7 +190,7 @@ func init() {
 	rootCmd.Flags().IntVarP(&durationDiagnosticTooling, "diag-tooling-collection-seconds", "d", 60, "the duration to run diagnostic collection tools like iostat, jstack etc")
 	rootCmd.Flags().IntVarP(&logAge, "log-age", "a", 0, "the maximum number of days to go back for log retreival (default is no filter and will retrieve all logs)")
 	rootCmd.Flags().StringVarP(&dremioGcDir, "dremio-gc-dir", "g", "/var/log/dremio", "directory where to find the GC logs")
-	rootCmd.Flags().IntVarP(&jfrEnable, "jfr", "j", 0, "enables collection of java flight recorder (jfr), time specified in seconds")
+	rootCmd.Flags().IntVarP(&jfrduration, "jfr", "j", 0, "enables collection of java flight recorder (jfr), time specified in seconds")
 	rootCmd.Flags().StringVarP(&sudoUser, "sudo-user", "b", "", "if any diagnostcs commands need a sudo user (i.e. for jcmd)")
 
 	// TODO implement embedded k8s and ssh support using go libs

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,8 @@ var kubectlPath string
 var isK8s bool
 var durationDiagnosticTooling int
 var logAge int
+var jfrEnable int
+var sudoUser string
 var GitSha = "unknown"
 var Version = "dev"
 
@@ -63,7 +65,7 @@ examples:
 
 ddc --coordinator 10.0.0.19 --executors 10.0.0.20,10.0.0.21,10.0.0.22 --ssh-key $HOME/.ssh/id_rsa_dremio --output diag.zip
 
-ddc --k8s --kubectl-path /opt/bin/kubectl --coordinator default:role=coordinator-dremio --executors default:role=executor-dremio --output diag.tar.gz
+ddc --k8s --kubectl-path /opt/bin/kubectl --coordinator default:app=dremio-coordinator-dremio --executors default:app=dremio-executor --output diag.tar.gz
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if sshKeyLoc == "" {
@@ -99,6 +101,8 @@ ddc --k8s --kubectl-path /opt/bin/kubectl --coordinator default:role=coordinator
 			GCLogOverride:             filepath.Clean(dremioGcDir),
 			DurationDiagnosticTooling: durationDiagnosticTooling,
 			LogAge:                    logAge,
+			JfrEnable:                 jfrEnable,
+			SudoUser:                  sudoUser,
 		}
 
 		// All dremio deployments will be Linux based so we have to switch the path seperator on these two elements
@@ -186,6 +190,8 @@ func init() {
 	rootCmd.Flags().IntVarP(&durationDiagnosticTooling, "diag-tooling-collection-seconds", "d", 60, "the duration to run diagnostic collection tools like iostat, jstack etc")
 	rootCmd.Flags().IntVarP(&logAge, "log-age", "a", 0, "the maximum number of days to go back for log retreival (default is no filter and will retrieve all logs)")
 	rootCmd.Flags().StringVarP(&dremioGcDir, "dremio-gc-dir", "g", "/var/log/dremio", "directory where to find the GC logs")
+	rootCmd.Flags().IntVarP(&jfrEnable, "jfr", "j", 0, "enables collection of java flight recorder (jfr), time specified in seconds")
+	rootCmd.Flags().StringVarP(&sudoUser, "sudo-user", "b", "", "if any diagnostcs commands need a sudo user (i.e. for jcmd)")
 
 	// TODO implement embedded k8s and ssh support using go libs
 	//rootCmd.Flags().BoolVar(&isEmbeddedK8s, "embedded-k8s", false, "use embedded k8s client in place of kubectl binary")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/rsvihladremio/dremio-diagnostic-collector/collection"
+	"github.com/rsvihladremio/dremio-diagnostic-collector/helpers"
 	"github.com/rsvihladremio/dremio-diagnostic-collector/kubernetes"
 	"github.com/rsvihladremio/dremio-diagnostic-collector/ssh"
 	"github.com/spf13/cobra"
@@ -135,9 +136,12 @@ ddc --k8s --kubectl-path /opt/bin/kubectl --coordinator default:app=dremio-coord
 			log.Print("using SSH based collection")
 			collectorStrategy = ssh.NewCmdSSHActions(sshKeyLoc, sshUser)
 		}
+		// Create ref to real file system (since with testing we redirect the argument to a mock object)
+		cfs := helpers.FileSystem{}
 		err = collection.Execute(collectorStrategy,
 			logOutput,
 			collectionArgs,
+			cfs,
 		)
 
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/rsvihladremio/dremio-diagnostic-collector/collection"
-	"github.com/rsvihladremio/dremio-diagnostic-collector/helpers"
 	"github.com/rsvihladremio/dremio-diagnostic-collector/kubernetes"
 	"github.com/rsvihladremio/dremio-diagnostic-collector/ssh"
 	"github.com/spf13/cobra"
@@ -137,11 +136,9 @@ ddc --k8s --kubectl-path /opt/bin/kubectl --coordinator default:app=dremio-coord
 			collectorStrategy = ssh.NewCmdSSHActions(sshKeyLoc, sshUser)
 		}
 		// Create ref to real file system (since with testing we redirect the argument to a mock object)
-		cfs := helpers.FileSystem{}
 		err = collection.Execute(collectorStrategy,
 			logOutput,
 			collectionArgs,
-			cfs,
 		)
 
 		if err != nil {

--- a/collection/capture.go
+++ b/collection/capture.go
@@ -96,7 +96,7 @@ func Capture(conf HostCaptureConfiguration) (files []CollectedFile, failedFiles 
 	logFiles := []string{}
 	var filterLogs bool
 
-	// set flag to filter or not ased on default value
+	// set flag to filter or not based on default value
 	if logAge == 0 {
 		filterLogs = false
 	} else {
@@ -241,6 +241,7 @@ func captureJFR(conf HostCaptureConfiguration) (err error) {
 		}
 		// non sudo user (typically with k8s) will have jcmd access
 		// sudo access is more typically needed with on-prem installs (ssh)
+		// TODO add logging levels and log all this output with a -vv or -v level
 		logger.Printf("INFO: starting JFR on host %v for %v seconds for pid %v", host, jfrDuration, pid)
 		if sudoUser == "" {
 			_, err := c.HostExecute(host, isCoordinator, diagnostics.JfrEnable(pid)...)
@@ -328,12 +329,12 @@ func setupDiagDir(conf HostCaptureConfiguration) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(outputLoc, host, "log/archive"), DirPerms); err != nil {
+	if err := os.MkdirAll(filepath.Join(outputLoc, host, "log", "archive"), DirPerms); err != nil {
 		logger.Printf("ERROR: host %v had error %v trying to make it's host log dir", host, err)
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(outputLoc, host, "log/json/archive"), DirPerms); err != nil {
+	if err := os.MkdirAll(filepath.Join(outputLoc, host, "log", "json", "archive"), DirPerms); err != nil {
 		logger.Printf("ERROR: host %v had error %v trying to make it's host log dir", host, err)
 		return err
 	}

--- a/collection/capture.go
+++ b/collection/capture.go
@@ -199,7 +199,7 @@ func captureJFR(conf HostCaptureConfiguration) (err error) {
 	sudoUser := conf.SudoUser
 	logdir := conf.DremioLogDir
 	start := time.Now().Format("2006-01-02T15-04-05")
-	jfrUniqId := logdir + "/" + start
+	jfrUniqID := logdir + "/" + start
 
 	// run jfr against the host:
 	// get the ps output and then deal with the filtering here
@@ -248,7 +248,7 @@ func captureJFR(conf HostCaptureConfiguration) (err error) {
 				logger.Printf("ERROR: host %v failed to enable JFR with error %v", host, err)
 				return err
 			}
-			_, err = c.HostExecute(host, isCoordinator, diagnostics.JfrRun(pid, jfrDuration, "dremio", jfrUniqId+".jfr")...)
+			_, err = c.HostExecute(host, isCoordinator, diagnostics.JfrRun(pid, jfrDuration, "dremio", jfrUniqID+".jfr")...)
 			if err != nil {
 				logger.Printf("ERROR: host %v failed to run JFR with error %v", host, err)
 				return err
@@ -260,7 +260,7 @@ func captureJFR(conf HostCaptureConfiguration) (err error) {
 				logger.Printf("ERROR: host %v failed to enable JFR with error %v", host, err)
 				return err
 			}
-			_, err = c.HostExecute(host, isCoordinator, diagnostics.JfrRunSudo(sudoUser, pid, jfrDuration, "dremio", jfrUniqId+".jfr")...)
+			_, err = c.HostExecute(host, isCoordinator, diagnostics.JfrRunSudo(sudoUser, pid, jfrDuration, "dremio", jfrUniqID+".jfr")...)
 			if err != nil {
 				logger.Printf("ERROR: host %v failed to run JFR with error %v", host, err)
 				return err

--- a/collection/capture.go
+++ b/collection/capture.go
@@ -228,6 +228,7 @@ func captureJFR(conf HostCaptureConfiguration) (err error) {
 		// Check for a running JFR
 		err := checkJfr(conf, pid)
 		if err != nil {
+			logger.Printf(err.Error())
 			return err
 		}
 		// non sudo user (typically with k8s) will have jcmd access
@@ -237,20 +238,24 @@ func captureJFR(conf HostCaptureConfiguration) (err error) {
 			_, err := c.HostExecute(host, isCoordinator, diagnostics.JfrEnable(pid)...)
 			if err != nil {
 				logger.Printf("ERROR: host %v failed to enable JFR with error %v", host, err)
+				return err
 			} else {
 				_, err := c.HostExecute(host, isCoordinator, diagnostics.JfrRun(pid, jfrDuration, "dremio", "/opt/dremio/data/"+host+".jfr")...)
 				if err != nil {
 					logger.Printf("ERROR: host %v failed to run JFR with error %v", host, err)
+					return err
 				}
 			}
 		} else {
 			_, err := c.HostExecute(host, isCoordinator, diagnostics.JfrEnableSudo(sudoUser, pid)...)
 			if err != nil {
 				logger.Printf("ERROR: host %v failed to enable JFR with error %v", host, err)
+				return err
 			} else {
 				_, err := c.HostExecute(host, isCoordinator, diagnostics.JfrRunSudo(sudoUser, pid, jfrDuration, "dremio", "/opt/dremio/data/"+host+".jfr")...)
 				if err != nil {
 					logger.Printf("ERROR: host %v failed to run JFR with error %v", host, err)
+					return err
 				}
 			}
 		}

--- a/collection/capture.go
+++ b/collection/capture.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/rsvihladremio/dremio-diagnostic-collector/diagnostics"
 )
@@ -196,6 +197,9 @@ func captureJFR(conf HostCaptureConfiguration) (err error) {
 	logger := conf.Logger
 	jfrDuration := conf.jfrduration
 	sudoUser := conf.SudoUser
+	logdir := conf.DremioLogDir
+	start := time.Now().Format("2006-01-02T15-04-05")
+	jfrUniqId := logdir + "/" + start
 
 	// run jfr against the host:
 	// get the ps output and then deal with the filtering here
@@ -244,7 +248,7 @@ func captureJFR(conf HostCaptureConfiguration) (err error) {
 				logger.Printf("ERROR: host %v failed to enable JFR with error %v", host, err)
 				return err
 			}
-			_, err = c.HostExecute(host, isCoordinator, diagnostics.JfrRun(pid, jfrDuration, "dremio", "/opt/dremio/data/"+host+".jfr")...)
+			_, err = c.HostExecute(host, isCoordinator, diagnostics.JfrRun(pid, jfrDuration, "dremio", jfrUniqId+".jfr")...)
 			if err != nil {
 				logger.Printf("ERROR: host %v failed to run JFR with error %v", host, err)
 				return err
@@ -256,7 +260,7 @@ func captureJFR(conf HostCaptureConfiguration) (err error) {
 				logger.Printf("ERROR: host %v failed to enable JFR with error %v", host, err)
 				return err
 			}
-			_, err = c.HostExecute(host, isCoordinator, diagnostics.JfrRunSudo(sudoUser, pid, jfrDuration, "dremio", "/opt/dremio/data/"+host+".jfr")...)
+			_, err = c.HostExecute(host, isCoordinator, diagnostics.JfrRunSudo(sudoUser, pid, jfrDuration, "dremio", jfrUniqId+".jfr")...)
 			if err != nil {
 				logger.Printf("ERROR: host %v failed to run JFR with error %v", host, err)
 				return err

--- a/collection/capture_test.go
+++ b/collection/capture_test.go
@@ -115,7 +115,6 @@ func (m *MockCollector) HostExecute(hostString string, isCoordinator bool, args 
 	return response[0].(string), response[1].(error)
 }
 func TestFindFiles(t *testing.T) {
-
 	expectedOutput := "/opt/file1\n/opt/file2\n"
 	var returnValues [][]interface{}
 	e := []interface{}{expectedOutput, nil}

--- a/collection/collector.go
+++ b/collection/collector.go
@@ -48,7 +48,7 @@ type Args struct {
 	GCLogOverride             string
 	DurationDiagnosticTooling int
 	LogAge                    int
-	JfrEnable                 int
+	JfrDuration               int
 	SudoUser                  string
 }
 
@@ -61,7 +61,7 @@ func Execute(c Collector, logOutput io.Writer, collectionArgs Args) error {
 	dremioLogDir := collectionArgs.DremioLogDir
 	dremioGcDir := collectionArgs.GCLogOverride
 	logAge := collectionArgs.LogAge
-	jfrEnable := collectionArgs.JfrEnable
+	jfrduration := collectionArgs.JfrDuration
 	sudoUser := collectionArgs.SudoUser
 
 	outputDir, err := os.MkdirTemp("", "*")
@@ -113,7 +113,7 @@ func Execute(c Collector, logOutput io.Writer, collectionArgs Args) error {
 				GCLogOverride:             dremioGcDir,
 				DurationDiagnosticTooling: collectionArgs.DurationDiagnosticTooling,
 				LogAge:                    logAge,
-				JfrEnable:                 jfrEnable,
+				jfrduration:               jfrduration,
 				SudoUser:                  sudoUser,
 			}
 			writtenFiles, failedFiles := Capture(coordinatorCaptureConf)
@@ -144,7 +144,7 @@ func Execute(c Collector, logOutput io.Writer, collectionArgs Args) error {
 				GCLogOverride:             dremioGcDir,
 				DurationDiagnosticTooling: collectionArgs.DurationDiagnosticTooling,
 				LogAge:                    logAge,
-				JfrEnable:                 jfrEnable,
+				jfrduration:               jfrduration,
 				SudoUser:                  sudoUser,
 			}
 			writtenFiles, failedFiles := Capture(executorCaptureConf)

--- a/collection/collector.go
+++ b/collection/collector.go
@@ -40,6 +40,7 @@ type Collector interface {
 }
 
 type Args struct {
+	Cfs                       helpers.FileSystem
 	CoordinatorStr            string
 	ExecutorsStr              string
 	OutputLoc                 string
@@ -53,7 +54,7 @@ type Args struct {
 	SudoUser                  string
 }
 
-func Execute(c Collector, logOutput io.Writer, collectionArgs Args, cfs helpers.Filesystem) error {
+func Execute(c Collector, logOutput io.Writer, collectionArgs Args) error {
 	start := time.Now().UTC()
 	coordinatorStr := collectionArgs.CoordinatorStr
 	executorsStr := collectionArgs.ExecutorsStr
@@ -64,6 +65,7 @@ func Execute(c Collector, logOutput io.Writer, collectionArgs Args, cfs helpers.
 	logAge := collectionArgs.LogAge
 	jfrduration := collectionArgs.JfrDuration
 	sudoUser := collectionArgs.SudoUser
+	cfs := collectionArgs.Cfs
 
 	outputDir, err := cfs.MkdirTemp("", "*")
 	if err != nil {

--- a/collection/collector.go
+++ b/collection/collector.go
@@ -48,6 +48,8 @@ type Args struct {
 	GCLogOverride             string
 	DurationDiagnosticTooling int
 	LogAge                    int
+	JfrEnable                 int
+	SudoUser                  string
 }
 
 func Execute(c Collector, logOutput io.Writer, collectionArgs Args) error {
@@ -59,6 +61,8 @@ func Execute(c Collector, logOutput io.Writer, collectionArgs Args) error {
 	dremioLogDir := collectionArgs.DremioLogDir
 	dremioGcDir := collectionArgs.GCLogOverride
 	logAge := collectionArgs.LogAge
+	jfrEnable := collectionArgs.JfrEnable
+	sudoUser := collectionArgs.SudoUser
 
 	outputDir, err := os.MkdirTemp("", "*")
 	if err != nil {
@@ -109,6 +113,8 @@ func Execute(c Collector, logOutput io.Writer, collectionArgs Args) error {
 				GCLogOverride:             dremioGcDir,
 				DurationDiagnosticTooling: collectionArgs.DurationDiagnosticTooling,
 				LogAge:                    logAge,
+				JfrEnable:                 jfrEnable,
+				SudoUser:                  sudoUser,
 			}
 			writtenFiles, failedFiles := Capture(coordinatorCaptureConf)
 			m.Lock()
@@ -138,6 +144,8 @@ func Execute(c Collector, logOutput io.Writer, collectionArgs Args) error {
 				GCLogOverride:             dremioGcDir,
 				DurationDiagnosticTooling: collectionArgs.DurationDiagnosticTooling,
 				LogAge:                    logAge,
+				JfrEnable:                 jfrEnable,
+				SudoUser:                  sudoUser,
 			}
 			writtenFiles, failedFiles := Capture(executorCaptureConf)
 			m.Lock()

--- a/collection/collector.go
+++ b/collection/collector.go
@@ -179,7 +179,7 @@ func Execute(c Collector, logOutput io.Writer, collectionArgs Args, cfs helpers.
 		return err
 	}
 	summaryFile := filepath.Join(outputDir, "summary.json")
-	err = os.WriteFile(summaryFile, []byte(o), 0600)
+	err = cfs.WriteFile(summaryFile, []byte(o), 0600)
 	if err != nil {
 		return fmt.Errorf("failed writing summary file '%v' due to error %v", summaryFile, err)
 	}

--- a/collection/collector_test.go
+++ b/collection/collector_test.go
@@ -94,6 +94,11 @@ func (f FakeFileSystem) RemoveAll(path string) error {
 	return err
 }
 
+func (f FakeFileSystem) WriteFile(name string, data []byte, perms os.FileMode) error {
+	err := os.WriteFile(name, data, perms)
+	return err
+}
+
 // Tempdir
 /*func (f FakeFileSystem) TempDir(dir string, pattern string) (string, error) {
 	path, err := os.MkdirTemp(dir, pattern)
@@ -214,10 +219,10 @@ func TestExecute(t *testing.T) {
 
 	fakeArgs.CoordinatorStr = "dremio"
 	fakeArgs.ExecutorsStr = "dremio"
-	host := "dremio-coordinator-0"
-	expected = "ERROR: host " + host + " failed iostat with error ERROR: host " + host + " command failed for iostat -y -x -d -c -t 1 5"
+	fakeArgs.OutputLoc = "/missng"
+	expected = "blah"
 	err = Execute(mockCollector, logOutput, fakeArgs, fakeFs)
-	if err.Error() != expected {
+	if err != nil && err.Error() != expected {
 		t.Errorf("ERROR: expected: %v, got: %v", expected, err)
 	}
 

--- a/collection/collector_test.go
+++ b/collection/collector_test.go
@@ -18,12 +18,210 @@
 package collection
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/rsvihladremio/dremio-diagnostic-collector/helpers"
 	"github.com/rsvihladremio/dremio-diagnostic-collector/tests"
 )
+
+type FakeFile struct {
+}
+
+type FakeFileSystem struct {
+}
+
+//Name
+func (f *FakeFile) Name() string {
+	return "fakeFile.txt"
+}
+
+// Write
+func (f *FakeFile) Write(b []byte) (n int, err error) {
+	fmt.Printf("Written: %v", b)
+	return 0, err
+}
+
+//Sync
+func (f *FakeFile) Sync() error {
+	return nil
+}
+
+// Close
+func (f *FakeFile) Close() error {
+	return nil
+}
+
+// Stat
+func (f FakeFileSystem) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+// Create
+func (f FakeFileSystem) Create(name string) (helpers.File, error) {
+	fmt.Println("Testing create")
+	return &FakeFile{}, nil
+}
+
+// Mkdir
+func (f FakeFileSystem) Mkdir(name string, perms os.FileMode) error {
+	err := os.Mkdir(name, perms)
+	return err
+}
+
+func (f FakeFileSystem) MkdirTemp(name string, pattern string) (string, error) {
+	dir, err := os.MkdirTemp(name, pattern)
+	return dir, err
+}
+
+func (f FakeFileSystem) MkdirAll(name string, perms os.FileMode) error {
+	err := os.MkdirAll(name, perms)
+	return err
+}
+
+// Remove
+func (f FakeFileSystem) Remove(path string) error {
+	err := os.Remove(path)
+	return err
+}
+
+// RemoveAll
+func (f FakeFileSystem) RemoveAll(path string) error {
+	err := os.RemoveAll(path)
+	return err
+}
+
+// Tempdir
+/*func (f FakeFileSystem) TempDir(dir string, pattern string) (string, error) {
+	path, err := os.MkdirTemp(dir, pattern)
+	return path, err
+}
+*/
+
+type MockCollector2 struct {
+	Returns []string
+	Calls   []string
+	//CallCounter int
+}
+
+type MockCopy2 struct {
+	HostString    string
+	IsCoordinator bool
+	Source        string
+	Destination   string
+}
+
+func (m *MockCollector2) FindHosts(searchTerm string) (response []string, err error) {
+	if searchTerm == "dremio" {
+		response = append(response, "dremio-coordinator-0", "dremio-executor-0", "dremio-executor-1")
+	} else {
+		response = append(response, "no results")
+		err = fmt.Errorf("ERROR: no hosts found matching %v", searchTerm)
+	}
+	return response, err
+}
+
+func (m *MockCollector2) CopyFromHost(hostString string, isCoordinator bool, source, destination string) (response string, err error) {
+	copyCall := MockCopy2{
+		HostString:    hostString,
+		IsCoordinator: isCoordinator,
+		Source:        source,
+		Destination:   destination,
+	}
+	if copyCall.Source == "/var/log/dremio" {
+		response = "INFO: logs copied from /var/log/dremio1"
+	} else if copyCall.Source == "/var/log/missing" {
+		response = "WARN: No logs found at /var/log/missing"
+	} else {
+		response = "no files found"
+		err = fmt.Errorf("ERROR: no files found for %v", copyCall.Source)
+	}
+	return response, err
+}
+
+func (m *MockCollector2) HostExecute(hostString string, isCoordinator bool, args ...string) (response string, err error) {
+	findConf := []string{"find", "/opt/dremio/conf/"}
+	findLog := []string{"find", "/var/log/dremio/"}
+	mockConfFiles := "/opt/dremio/dremio.conf\n/opt/dremio/dremio.env"
+	mockLogFiles := "/var/log/dremio/server.out\n/var/log/dremio/server.log"
+	fullCmd := strings.Join(args, " ")
+
+	// conf files or log files
+	if args[0] == findConf[0] && args[1] == findConf[1] {
+		response = mockConfFiles
+	} else if args[0] == findLog[0] && args[1] == findLog[1] {
+		response = mockLogFiles
+	} else {
+		response = "no results"
+		err = fmt.Errorf("ERROR: host %v command failed for %v", hostString, fullCmd)
+	}
+	return response, err
+}
+
+func TestExecute(t *testing.T) {
+	var returnValues []string
+	var callValues []string
+	callValues = append(callValues, "dremio-coordinator-1", "dremio-eecutor-0", "dremio-executor-1")
+	mockCollector := &MockCollector2{
+		Calls:   callValues,
+		Returns: returnValues,
+	}
+	logOutput := os.Stdout
+	fakeFs := FakeFileSystem{}
+	fakeTmp, _ := fakeFs.MkdirTemp("dremio", "*")
+	fakeArgs := Args{
+		CoordinatorStr:            "10.1.2.3",
+		ExecutorsStr:              "10.2.3.4",
+		OutputLoc:                 fakeTmp,
+		DremioConfDir:             "/opt/dremio/conf",
+		DremioLogDir:              "/var/log/dremio",
+		DremioGcDir:               "/var/log/dremio",
+		GCLogOverride:             "",
+		DurationDiagnosticTooling: 5,
+		LogAge:                    1,
+	}
+	expected := "ERROR: no hosts found matching 10.1.2.3"
+	err := Execute(mockCollector, logOutput, fakeArgs, fakeFs)
+	if err.Error() != expected {
+		t.Errorf("ERROR: expected: %v, got: %v", expected, err)
+	}
+
+	fakeArgs.CoordinatorStr = "dremio-coordinator-99"
+	expected = "ERROR: no hosts found matching dremio-coordinator-99"
+	err = Execute(mockCollector, logOutput, fakeArgs, fakeFs)
+	if err.Error() != expected {
+		t.Errorf("ERROR: expected: %v, got: %v", expected, err)
+	}
+
+	fakeArgs.CoordinatorStr = "dremio"
+	//fakeArgs.ExecutorsStr = "dremio-executor-99"
+	expected = "ERROR: no hosts found matching 10.2.3.4"
+	err = Execute(mockCollector, logOutput, fakeArgs, fakeFs)
+	if err.Error() != expected {
+		t.Errorf("ERROR: expected: %v, got: %v", expected, err)
+	}
+
+	fakeArgs.CoordinatorStr = "dremio"
+	fakeArgs.ExecutorsStr = "dremio-executor-99"
+	expected = "ERROR: no hosts found matching dremio-executor-99"
+	err = Execute(mockCollector, logOutput, fakeArgs, fakeFs)
+	if err.Error() != expected {
+		t.Errorf("ERROR: expected: %v, got: %v", expected, err)
+	}
+
+	fakeArgs.CoordinatorStr = "dremio"
+	fakeArgs.ExecutorsStr = "dremio"
+	host := "dremio-coordinator-0"
+	expected = "ERROR: host " + host + " failed iostat with error ERROR: host " + host + " command failed for iostat -y -x -d -c -t 1 5"
+	err = Execute(mockCollector, logOutput, fakeArgs, fakeFs)
+	if err.Error() != expected {
+		t.Errorf("ERROR: expected: %v, got: %v", expected, err)
+	}
+
+}
 
 func TestArchive(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/diagnostics/jfr.go
+++ b/diagnostics/jfr.go
@@ -1,0 +1,55 @@
+/*
+   Copyright 2022 Ryan SVIHLA
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// diagnostics contains all the commands that run server diagnostics to find problems on the host
+package diagnostics
+
+import "fmt"
+
+/*
+Commands used to run a JFR typically
+export DREMIO_PID=$(ps ax | grep dremio | grep -v grep | awk '{print $1}')
+jcmd $DREMIO_PID VM.unlock_commercial_features
+jcmd $DREMIO_PID JFR.start name="DR_JFR" settings=profile maxage=21600s filename=/tmp/coordinator.jfr dumponexit=true
+*/
+
+func JfrPid() []string {
+	//return []string{"bash -c", "ps ax | grep dremio", "|", "grep", "-v", "grep", "|", "awk", "'{print", "$1}'"}
+	return []string{"ps", "ax"}
+}
+func JfrEnable(pid string) []string {
+	return []string{"jcmd", pid, "VM.unlock_commercial_features"}
+}
+
+func JfrEnableSudo(sudouser string, pid string) []string {
+	return []string{"sudo", "-u", sudouser, "jcmd", pid, "VM.unlock_commercial_features"}
+}
+
+func JfrRun(pid string, duration int, jfrname string, jfrpath string) []string {
+	return []string{"jcmd", pid, "JFR.start", "name=" + jfrname, "settings=profile", "maxage=" + fmt.Sprint(duration) + "s", "filename=" + jfrpath, "dumponexit=true"}
+}
+
+func JfrRunSudo(sudouser string, pid string, duration int, jfrname string, jfrpath string) []string {
+	return []string{"sudo", "-u", sudouser, "jcmd", pid, "JFR.start", "name=" + jfrname, "settings=profile", "maxage=" + fmt.Sprint(duration) + "s", "filename=" + jfrpath, "dumponexit=true"}
+}
+
+func JfrCheck(pid string) []string {
+	return []string{"jcmd", pid, "JFR.check"}
+}
+
+func JfrCheckSudo(sudouser string, pid string) []string {
+	return []string{"sudo", "-u", sudouser, "jcmd", pid, "JFR.check"}
+}

--- a/diagnostics/jfr_test.go
+++ b/diagnostics/jfr_test.go
@@ -1,0 +1,79 @@
+/*
+   Copyright 2022 Ryan SVIHLA
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// diagnostics contains all the commands that run server diagnostics to find problems on the host
+package diagnostics
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestJFRPid(t *testing.T) {
+	result := JfrPid()
+	expected := []string{"ps", "ax"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %#v but was %#v", expected, result)
+	}
+}
+
+func TestJFREnable(t *testing.T) {
+	result := JfrEnable("1")
+	expected := []string{"jcmd", "1", "VM.unlock_commercial_features"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %#v but was %#v", expected, result)
+	}
+}
+
+func TestJFREnableSudo(t *testing.T) {
+	result := JfrEnableSudo("dremio", "1")
+	expected := []string{"sudo", "-u", "dremio", "jcmd", "1", "VM.unlock_commercial_features"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %#v but was %#v", expected, result)
+	}
+}
+
+func TestJFRRun(t *testing.T) {
+	result := JfrRun("1", 600, "dremio", "/opt/dremio/data")
+	expected := []string{"jcmd", "1", "JFR.start", "name=dremio", "settings=profile", "maxage=600s", "filename=/opt/dremio/data", "dumponexit=true"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %#v but was %#v", expected, result)
+	}
+}
+
+func TestJFRRunSudo(t *testing.T) {
+	result := JfrRunSudo("dremio", "1", 600, "dremio", "/opt/dremio/data")
+	expected := []string{"sudo", "-u", "dremio", "jcmd", "1", "JFR.start", "name=dremio", "settings=profile", "maxage=600s", "filename=/opt/dremio/data", "dumponexit=true"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %#v but was %#v", expected, result)
+	}
+}
+
+func TestJFRCheck(t *testing.T) {
+	result := JfrCheck("600")
+	expected := []string{"jcmd", "600", "JFR.check"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %#v but was %#v", expected, result)
+	}
+}
+
+func TestJFRCheckSudo(t *testing.T) {
+	result := JfrCheckSudo("dremio", "600")
+	expected := []string{"sudo", "-u", "dremio", "jcmd", "600", "JFR.check"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %#v but was %#v", expected, result)
+	}
+}

--- a/helpers/fshelper.go
+++ b/helpers/fshelper.go
@@ -29,6 +29,7 @@ type Filesystem interface {
 	MkdirTemp(name string, pattern string) (string, error)
 	RemoveAll(path string) error
 	Remove(name string) error
+	WriteFile(name string, data []byte, perms os.FileMode) error
 	//TempDir(dir, prefix string) (string, error)
 	//TempFile(dir, prefix string) (File, error)
 }
@@ -102,14 +103,19 @@ func (f FileSystem) MkdirAll(name string, perms os.FileMode) error {
 }
 
 // Remove
-func (fs FileSystem) Remove(path string) error {
+func (f FileSystem) Remove(path string) error {
 	err := os.Remove(path)
 	return err
 }
 
 // RemoveAll
-func (fs FileSystem) RemoveAll(path string) error {
+func (f FileSystem) RemoveAll(path string) error {
 	err := os.RemoveAll(path)
+	return err
+}
+
+func (f FileSystem) WriteFile(name string, data []byte, perms os.FileMode) error {
+	err := os.WriteFile(name, data, perms)
 	return err
 }
 

--- a/helpers/fshelper.go
+++ b/helpers/fshelper.go
@@ -1,0 +1,122 @@
+/*
+   Copyright 2022 Ryan SVIHLA
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// oshelper package provides functions to wrapper os file system calls
+// to better facilitate testing
+
+package helpers
+
+import "os"
+
+type Filesystem interface {
+	Stat(name string) (os.FileInfo, error)
+	Create(name string) (File, error)
+	MkdirAll(path string, perm os.FileMode) error
+	Mkdir(path string, perm os.FileMode) error
+	MkdirTemp(name string, pattern string) (string, error)
+	RemoveAll(path string) error
+	Remove(name string) error
+	//TempDir(dir, prefix string) (string, error)
+	//TempFile(dir, prefix string) (File, error)
+}
+
+type File interface {
+	Name() string
+	Write(b []byte) (n int, err error)
+	Sync() error
+	Close() error
+}
+
+// Real file
+type RealFile struct {
+	file *os.File
+}
+
+// RealFileSystem wrapper
+type FileSystem struct{}
+
+//Name
+func (f *RealFile) Name() string {
+	return f.file.Name()
+}
+
+// Write
+func (f *RealFile) Write(b []byte) (n int, err error) {
+	return f.file.Write(b)
+}
+
+//Sync
+func (f *RealFile) Sync() error {
+	return f.file.Sync()
+}
+
+// Close
+func (f *RealFile) Close() error {
+	return f.Close()
+}
+
+// Stat
+func (f FileSystem) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+// Create
+func (f FileSystem) Create(name string) (File, error) {
+	fd, err := os.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	realFile := &RealFile{
+		file: fd,
+	}
+	return realFile, nil
+}
+
+// Mkdir
+func (f FileSystem) Mkdir(name string, perms os.FileMode) error {
+	err := os.Mkdir(name, perms)
+	return err
+}
+
+func (f FileSystem) MkdirTemp(name string, pattern string) (string, error) {
+	dir, err := os.MkdirTemp(name, pattern)
+	return dir, err
+}
+
+func (f FileSystem) MkdirAll(name string, perms os.FileMode) error {
+	err := os.MkdirAll(name, perms)
+	return err
+}
+
+// Remove
+func (fs FileSystem) Remove(path string) error {
+	err := os.Remove(path)
+	return err
+}
+
+// RemoveAll
+func (fs FileSystem) RemoveAll(path string) error {
+	err := os.RemoveAll(path)
+	return err
+}
+
+// Temptdir
+/*
+func (fs FileSystem) TempDir(dir string, pattern string) (string, error) {
+	path, err := os.MkdirTemp(dir, pattern)
+	return path, err
+}
+*/

--- a/helpers/fshelper.go
+++ b/helpers/fshelper.go
@@ -51,7 +51,7 @@ type RealFile struct {
 // RealFileSystem wrapper
 type FileSystem struct{}
 
-//Name
+// Name
 func (f *RealFile) Name() string {
 	return f.file.Name()
 }
@@ -131,7 +131,7 @@ type FakeFile struct {
 type FakeFileSystem struct {
 }
 
-//Name
+// Name
 func (f *FakeFile) Name() string {
 	return "fakeFile.txt"
 }
@@ -142,7 +142,7 @@ func (f *FakeFile) Write(b []byte) (n int, err error) {
 	return 0, err
 }
 
-//Sync
+// Sync
 func (f *FakeFile) Sync() error {
 	return nil
 }

--- a/helpers/fshelper.go
+++ b/helpers/fshelper.go
@@ -69,7 +69,7 @@ func (f *RealFile) Sync() error {
 
 // Close
 func (f *RealFile) Close() error {
-	return f.Close()
+	return f.file.Close()
 }
 
 // Stat

--- a/helpers/fshelper.go
+++ b/helpers/fshelper.go
@@ -22,6 +22,7 @@ package helpers
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 type Filesystem interface {
@@ -79,7 +80,7 @@ func (f FileSystem) Stat(name string) (os.FileInfo, error) {
 
 // Create
 func (f FileSystem) Create(name string) (File, error) {
-	fd, err := os.Create(name)
+	fd, err := os.Create(filepath.Clean(name))
 	if err != nil {
 		return nil, err
 	}

--- a/helpers/fshelper.go
+++ b/helpers/fshelper.go
@@ -34,8 +34,6 @@ type Filesystem interface {
 	RemoveAll(path string) error
 	Remove(name string) error
 	WriteFile(name string, data []byte, perms os.FileMode) error
-	//TempDir(dir, prefix string) (string, error)
-	//TempFile(dir, prefix string) (File, error)
 }
 
 type File interface {
@@ -63,7 +61,7 @@ func (f *RealFile) Write(b []byte) (n int, err error) {
 	return f.file.Write(b)
 }
 
-//Sync
+// Sync
 func (f *RealFile) Sync() error {
 	return f.file.Sync()
 }
@@ -96,11 +94,13 @@ func (f FileSystem) Mkdir(name string, perms os.FileMode) error {
 	return err
 }
 
+// MkdirTemp
 func (f FileSystem) MkdirTemp(name string, pattern string) (string, error) {
 	dir, err := os.MkdirTemp(name, pattern)
 	return dir, err
 }
 
+// MkdirAll
 func (f FileSystem) MkdirAll(name string, perms os.FileMode) error {
 	err := os.MkdirAll(name, perms)
 	return err
@@ -118,11 +118,13 @@ func (f FileSystem) RemoveAll(path string) error {
 	return err
 }
 
+// WriteFile
 func (f FileSystem) WriteFile(name string, data []byte, perms os.FileMode) error {
 	err := os.WriteFile(name, data, perms)
 	return err
 }
 
+// Fake file handlers (for testing)
 type FakeFile struct {
 }
 
@@ -167,11 +169,13 @@ func (f FakeFileSystem) Mkdir(name string, perms os.FileMode) error {
 	return err
 }
 
+// MkdirTemp
 func (f FakeFileSystem) MkdirTemp(name string, pattern string) (string, error) {
 	dir, err := os.MkdirTemp(name, pattern)
 	return dir, err
 }
 
+// MkdirAll
 func (f FakeFileSystem) MkdirAll(name string, perms os.FileMode) error {
 	err := os.MkdirAll(name, perms)
 	return err
@@ -189,6 +193,7 @@ func (f FakeFileSystem) RemoveAll(path string) error {
 	return err
 }
 
+// Writefile
 func (f FakeFileSystem) WriteFile(name string, data []byte, perms os.FileMode) error {
 	err := os.WriteFile(name, data, perms)
 	return err

--- a/helpers/fshelper.go
+++ b/helpers/fshelper.go
@@ -19,7 +19,10 @@
 
 package helpers
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 type Filesystem interface {
 	Stat(name string) (os.FileInfo, error)
@@ -119,10 +122,73 @@ func (f FileSystem) WriteFile(name string, data []byte, perms os.FileMode) error
 	return err
 }
 
-// Temptdir
-/*
-func (fs FileSystem) TempDir(dir string, pattern string) (string, error) {
-	path, err := os.MkdirTemp(dir, pattern)
-	return path, err
+type FakeFile struct {
 }
-*/
+
+type FakeFileSystem struct {
+}
+
+//Name
+func (f *FakeFile) Name() string {
+	return "fakeFile.txt"
+}
+
+// Write
+func (f *FakeFile) Write(b []byte) (n int, err error) {
+	fmt.Printf("Written: %v", b)
+	return 0, err
+}
+
+//Sync
+func (f *FakeFile) Sync() error {
+	return nil
+}
+
+// Close
+func (f *FakeFile) Close() error {
+	return nil
+}
+
+// Stat
+func (f FakeFileSystem) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+// Create
+func (f FakeFileSystem) Create(name string) (File, error) {
+	fmt.Println("Testing create")
+	return &FakeFile{}, nil
+}
+
+// Mkdir
+func (f FakeFileSystem) Mkdir(name string, perms os.FileMode) error {
+	err := os.Mkdir(name, perms)
+	return err
+}
+
+func (f FakeFileSystem) MkdirTemp(name string, pattern string) (string, error) {
+	dir, err := os.MkdirTemp(name, pattern)
+	return dir, err
+}
+
+func (f FakeFileSystem) MkdirAll(name string, perms os.FileMode) error {
+	err := os.MkdirAll(name, perms)
+	return err
+}
+
+// Remove
+func (f FakeFileSystem) Remove(path string) error {
+	err := os.Remove(path)
+	return err
+}
+
+// RemoveAll
+func (f FakeFileSystem) RemoveAll(path string) error {
+	err := os.RemoveAll(path)
+	return err
+}
+
+func (f FakeFileSystem) WriteFile(name string, data []byte, perms os.FileMode) error {
+	err := os.WriteFile(name, data, perms)
+	return err
+}


### PR DESCRIPTION
Adds JFR collection and tests. Tested on K8s and On prem. JFR is enabled with a flag and duration in seconds

The JFR is triggered along with a normal collection but the tool does not wait for the JFR to complete. I have left this up to the user to decide when to re-run another collection to pickup the JFR file, since the JFR could be set for any time really

There is a check that a JFR is not already running on the instance / pod since we don't want to trigger more than one. Although it is possible to run more than one JFR on a JVM, we don't really want to give the tool the capability to spawn multiple JFRs and potentially cause problems.

The JFR output dir defaults to the same directory as the logs (including if a user passes in a custom log directory), this is so the normal collection will pickup the JFR file.