### PR TITLE
improved UX and gc log detection

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -17,6 +17,7 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -27,6 +28,7 @@ import (
 
 type CmdExecutor interface {
 	Execute(args ...string) (out string, err error)
+	ExecuteAndStreamOutput(outputHandler OutputHandler, args ...string) error
 }
 
 type UnableToStartErr struct {
@@ -43,8 +45,71 @@ type ExecuteCliErr struct {
 	Cmd string
 }
 
+// OutputHandler is a function type that processes lines of output
+type OutputHandler func(line string)
+
 // Cli
 type Cli struct {
+}
+
+// ExecuteAndStreamOutput runs a system command and streams the output (stdout)
+// and errors (stderr) to the provided output handler function.
+// This function will run the command specified by the args parameters.
+// The first arg should be the command itself, and the rest of the args should be its parameters.
+// The outputHandler is a callback function that is called with each line of output and error from the command.
+// If the command runs successfully, the function will return nil. If there's an error executing the command,
+// it will return an error. Note that an error from the command itself (e.g., a non-zero exit status) will also
+// be returned as an error from this function.
+func (c *Cli) ExecuteAndStreamOutput(outputHandler OutputHandler, args ...string) error {
+	// Log the command that's about to be run
+	fmt.Printf("args: %v\n", strings.Join(args, " "))
+
+	// Create the command based on the passed arguments
+	cmd := exec.Command(args[0], args[1:]...)
+
+	// Create a pipe to get the standard output from the command
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return UnableToStartErr{Err: err, Cmd: strings.Join(args, " ")}
+	}
+
+	// Create a pipe to get the error output from the command
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return UnableToStartErr{Err: err, Cmd: strings.Join(args, " ")}
+	}
+
+	// Start the command
+	if err := cmd.Start(); err != nil {
+		return UnableToStartErr{Err: err, Cmd: strings.Join(args, " ")}
+	}
+
+	// Asynchronously read the output from the command line by line
+	// and pass it to the outputHandler. This runs in a goroutine
+	// so that we can also read the error output at the same time.
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			outputHandler(scanner.Text())
+		}
+	}()
+
+	// Asynchronously read the error output from the command line by line
+	// and pass it to the outputHandler.
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			outputHandler(scanner.Text())
+		}
+	}()
+
+	// Wait for the command to finish
+	if err := cmd.Wait(); err != nil {
+		return UnableToStartErr{Err: err, Cmd: strings.Join(args, " ")}
+	}
+
+	// If there was no error, return nil
+	return nil
 }
 
 func (c *Cli) Execute(args ...string) (string, error) {

--- a/cli/cli_suite_test.go
+++ b/cli/cli_suite_test.go
@@ -1,0 +1,13 @@
+package cli_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCli(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cli Suite")
+}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,87 +1,101 @@
-//	Copyright 2023 Dremio Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// package cli provides wrapper support for executing commands, this is so
-// we can test the rest of the implementations quickly.
-package cli
+package cli_test
 
 import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rsvihladremio/dremio-diagnostic-collector/cli"
 )
 
-func TestCli(t *testing.T) {
+var _ = Describe("Cli", func() {
+	var (
+		c              *cli.Cli
+		outputHandler  cli.OutputHandler
+		executedOutput string
+	)
 
-	c := Cli{}
-	var err error
-	var out string
-	var expectedOut string
-	if runtime.GOOS == "windows" {
-		out, err = c.Execute("cmd.exe", "/c", "dir", "/B", filepath.Join("testdata", "ls"))
-		expectedOut = "file1\r\nfile2\r\n"
-	} else {
-		out, err = c.Execute("ls", "-a", filepath.Join("testdata", "ls"))
-		expectedOut = "file1\nfile2\n"
-	}
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
-	// have to use contains because we are getting some extra output
-	if !strings.Contains(out, expectedOut) {
-		t.Errorf("expected %q but was %q", expectedOut, out)
-	}
-}
+	BeforeEach(func() {
+		c = &cli.Cli{}
+		executedOutput = ""
+		outputHandler = func(line string) {
+			executedOutput += line + "\n"
+		}
+	})
 
-func TestCliWithNoArgsForTheCommand(t *testing.T) {
+	Describe("ExecuteAndStreamOutput", func() {
+		Context("with a valid command", func() {
+			It("should stream the command output", func() {
+				err := c.ExecuteAndStreamOutput(outputHandler, "echo", "Hello, World!")
+				Expect(err).To(BeNil())
+				Expect(strings.TrimSpace(executedOutput)).To(Equal("Hello, World!"))
+			})
+		})
 
-	c := Cli{}
-	var err error
-	var out string
-	var expectedOut string
-	if runtime.GOOS == "windows" {
-		out, err = c.Execute("cmd.exe")
-		expectedOut = "Microsoft"
-	} else {
-		out, err = c.Execute("ls")
-		expectedOut = "cli.go"
-	}
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
-	// have to use contains because we are getting some extra output
-	if !strings.Contains(out, expectedOut) {
-		t.Errorf("expected %q but was %q", expectedOut, out)
-	}
-}
+		Context("with a command that produces stderr", func() {
+			It("should stream the command error output", func() {
+				err := c.ExecuteAndStreamOutput(outputHandler, "cat", "nonexistentfile")
+				Expect(err).ToNot(BeNil())
+				Expect(strings.TrimSpace(executedOutput)).To(ContainSubstring("No such file or directory"))
+			})
+		})
 
-func TestCliWithBadCommand(t *testing.T) {
+		Context("with an invalid command", func() {
+			It("should return an error", func() {
+				err := c.ExecuteAndStreamOutput(outputHandler, "22JIDJMJMHHF")
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(BeAssignableToTypeOf(cli.UnableToStartErr{}))
+				expectedErr := "unable to start command '22JIDJMJMHHF' due to error"
+				Expect(strings.Contains(err.Error(), expectedErr)).To(BeTrue())
+			})
+		})
+	})
 
-	c := Cli{}
-	_, err := c.Execute("22JIDJMJMHHF")
-	if err == nil {
-		t.Error("expected error")
-	}
-	switch v := err.(type) {
-	case UnableToStartErr:
-		t.Log("expected error is correct")
-	default:
-		t.Errorf("unexpected error type %T but expected ExecuteCliErr", v)
-	}
-	expectedErr := "unable to start command '22JIDJMJMHHF' due to error"
-	if !strings.Contains(err.Error(), expectedErr) {
-		t.Errorf("expected error to contain %v but was %v", expectedErr, err)
-	}
-}
+	Describe("Execute", func() {
+		Context("when the command is valid", func() {
+			It("should execute the command and return the output", func() {
+				var expectedOut string
+				var out string
+				var err error
+				if runtime.GOOS == "windows" {
+					out, err = c.Execute("cmd.exe", "/c", "dir", "/B", filepath.Join("testdata", "ls"))
+					expectedOut = "file1\r\nfile2\r\n"
+				} else {
+					out, err = c.Execute("ls", "-a", filepath.Join("testdata", "ls"))
+					expectedOut = "file1\nfile2\n"
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(strings.Contains(out, expectedOut)).To(BeTrue())
+			})
+		})
+
+		Context("when no arguments are provided for the command", func() {
+			It("should execute the command and return the output", func() {
+				var expectedOut string
+				var out string
+				var err error
+				if runtime.GOOS == "windows" {
+					out, err = c.Execute("cmd.exe")
+					expectedOut = "Microsoft"
+				} else {
+					out, err = c.Execute("ls")
+					expectedOut = "cli.go"
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(strings.Contains(out, expectedOut)).To(BeTrue())
+			})
+		})
+
+		Context("when the command is invalid", func() {
+			It("should return an error", func() {
+				_, err := c.Execute("22JIDJMJMHHF")
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(BeAssignableToTypeOf(cli.UnableToStartErr{}))
+				expectedErr := "unable to start command '22JIDJMJMHHF' due to error"
+				Expect(strings.Contains(err.Error(), expectedErr)).To(BeTrue())
+			})
+		})
+	})
+})

--- a/cmd/local/logcollect/logcollect.go
+++ b/cmd/local/logcollect/logcollect.go
@@ -72,7 +72,11 @@ func (l *Collector) RunCollectDremioServerLog() error {
 }
 
 func (l *Collector) RunCollectGcLogs() error {
-	simplelog.Info("Collecting GC logs ...")
+	if l.gcLogsDir == "" {
+		simplelog.Warningf("Skipping GC Logs no gc log directory is configured set dremio-gclogs-dir in ddc.yaml")
+	} else {
+		simplelog.Info("Collecting GC logs ...")
+	}
 	files, err := os.ReadDir(path.Clean(l.gcLogsDir))
 	if err != nil {
 		return fmt.Errorf("error reading directory: %w", err)

--- a/collection/capture.go
+++ b/collection/capture.go
@@ -80,11 +80,13 @@ func Capture(conf HostCaptureConfiguration, localDDCPath, localDDCYamlPath, outp
 		simplelog.Infof("sucessfully copied ddc.yaml to host %v", host)
 	}
 	//execute local-collect
-	if out, err := ComposeExecute(conf, []string{pathToDDC, "local-collect"}); err != nil {
-		simplelog.Warningf("on host %v catpure faileddue to error '%v' with output '%v'", host, err, out)
+	if err := ComposeExecuteAndStream(conf, func(line string) {
+		fmt.Printf("HOST %v - %v\n", host, line)
+	}, []string{pathToDDC, "local-collect"}); err != nil {
+		simplelog.Warningf("on host %v capture failed due to error '%v'", host, err)
 		//return
 	} else {
-		simplelog.Infof("on host %v catpure successful with output '%v'", host, out)
+		simplelog.Infof("on host %v capture successful", host)
 	}
 	//defer delete tar.gz
 	defer func() {

--- a/collection/collector.go
+++ b/collection/collector.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rsvihladremio/dremio-diagnostic-collector/cli"
 	"github.com/rsvihladremio/dremio-diagnostic-collector/cmd/simplelog"
 	"github.com/rsvihladremio/dremio-diagnostic-collector/helpers"
 )
@@ -48,6 +49,7 @@ type Collector interface {
 	CopyToHostSudo(hostString string, isCoordinator bool, sudoUser, source, destination string) (out string, err error)
 	FindHosts(searchTerm string) (podName []string, err error)
 	HostExecute(hostString string, isCoordinator bool, args ...string) (stdOut string, err error)
+	HostExecuteAndStream(hostString string, output cli.OutputHandler, isCoordinator bool, args ...string) error
 }
 
 type Args struct {

--- a/collection/collector_test.go
+++ b/collection/collector_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rsvihladremio/dremio-diagnostic-collector/cli"
 	"github.com/rsvihladremio/dremio-diagnostic-collector/helpers"
 	"github.com/rsvihladremio/dremio-diagnostic-collector/pkg/tests"
 )
@@ -175,6 +176,13 @@ func (m *MockCapCollector) CopyFromHostSudo(hostString string, isCoordinator boo
 		err = fmt.Errorf("ERROR: no files found for %v", copyCall.Source)
 	}
 	return response, err
+}
+
+func (m *MockCapCollector) HostExecuteAndStream(hostString string, output cli.OutputHandler, _ bool, args ...string) error {
+	fullCmd := strings.Join(args, " ")
+	response := "Mock execute for " + hostString + " command: " + fullCmd
+	output(response)
+	return nil
 }
 
 func (m *MockCapCollector) HostExecute(hostString string, _ bool, args ...string) (response string, err error) {

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -50,6 +50,12 @@ func (c *KubectlK8sActions) getContainerName(isCoordinator bool) string {
 	return c.executorContainer
 }
 
+func (c *KubectlK8sActions) HostExecuteAndStream(hostString string, output cli.OutputHandler, isCoordinator bool, args ...string) (err error) {
+	kubectlArgs := []string{c.kubectlPath, "exec", "-n", c.namespace, "-c", c.getContainerName(isCoordinator), hostString, "--"}
+	kubectlArgs = append(kubectlArgs, args...)
+	return c.cli.ExecuteAndStreamOutput(output, kubectlArgs...)
+}
+
 func (c *KubectlK8sActions) HostExecute(hostString string, isCoordinator bool, args ...string) (out string, err error) {
 	kubectlArgs := []string{c.kubectlPath, "exec", "-n", c.namespace, "-c", c.getContainerName(isCoordinator), hostString, "--"}
 	kubectlArgs = append(kubectlArgs, args...)

--- a/pkg/tests/mocks.go
+++ b/pkg/tests/mocks.go
@@ -15,6 +15,8 @@
 // package tests provides helper functions and mocks for running tests
 package tests
 
+import "github.com/rsvihladremio/dremio-diagnostic-collector/cli"
+
 type MockCli struct {
 	Calls          [][]string
 	StoredResponse []string
@@ -25,4 +27,11 @@ func (m *MockCli) Execute(args ...string) (out string, err error) {
 	m.Calls = append(m.Calls, args)
 	length := len(m.Calls)
 	return m.StoredResponse[length-1], m.StoredErrors[length-1]
+}
+
+func (m *MockCli) ExecuteAndStreamOutput(output cli.OutputHandler, args ...string) (err error) {
+	m.Calls = append(m.Calls, args)
+	length := len(m.Calls)
+	output(m.StoredResponse[length-1])
+	return m.StoredErrors[length-1]
 }

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -39,6 +39,13 @@ type CmdSSHActions struct {
 	sshUser string
 }
 
+func (c *CmdSSHActions) HostExecuteAndStream(hostString string, output cli.OutputHandler, _ bool, args ...string) (err error) {
+	sshArgs := []string{"ssh", "-i", c.sshKey, "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no"}
+	sshArgs = append(sshArgs, fmt.Sprintf("%v@%v", c.sshUser, hostString))
+	sshArgs = append(sshArgs, strings.Join(args, " "))
+	return c.cli.ExecuteAndStreamOutput(output, sshArgs...)
+}
+
 func (c *CmdSSHActions) CopyFromHost(hostName string, _ bool, source, destination string) (string, error) {
 	return c.cli.Execute("scp", "-i", c.sshKey, "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", fmt.Sprintf("%v@%v:%v", c.sshUser, hostName, source), destination)
 }


### PR DESCRIPTION
* jps -v is now used to parse startup flags, this works more consistently than ps -f
* logs now stream from the nodes capturing this give a sense of progress
* gclog detection was running on the root ddc command, this has been moved to a later evaluation time than the init() command
* gclog detection now will log a warn if it overrides a setting
* default gclog directory is now empty in ddc.yaml this should usually not need to be set
* matcher on gc logs now will match .current files
* if no gc log is set or found the gc log collection skips